### PR TITLE
Add PyCon Taiwan 2025 lightning talk

### DIFF
--- a/content/speaking/contents.lr
+++ b/content/speaking/contents.lr
@@ -8,6 +8,7 @@ full_title: 演講列表
 ---
 body:
 
+* 2025-09-07 「人人都是星艦工程師：與AI打造專屬你的天文探索App」 @PyCon Taiwan 2025閃電秀 (<a href="https://hackmd.io/@astrobackhacker/H1mF7lqdle#/" target="_blank">簡報</a>)
 * 2025-05-18 「人人都是星艦工程師：與AI打造專屬你的天文探索App」 @2025天文年會 (<a href="https://hackmd.io/@astrobackhacker/HygrFZjelg#/" target="_blank">簡報</a>)
 * 2024-12-07 「探索天文資料好困難？用生成式AI變得簡單又有趣！」 @資料科學家的工作日常直播 (<a href="http://astrobackhacker.tw/live4dsdaily/" target="_blank">簡報</a>)
 * 2024-11-26 「生成式AI如何協助師生用Python探索天文資料？」 @全國高中地球科學教師研習 (<a href="https://astrobackhacker.tw/2024EarthSciTeachersWorkshop/" target="_blank">簡報</a>)


### PR DESCRIPTION
## Summary
- add PyCon Taiwan 2025 lightning talk to the top of the talks list with slide link

## Testing
- `pip install lektor` *(fails: Could not connect to proxy)*
- `lektor build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69d5919bc8323980c4978528f7963